### PR TITLE
Terraform 상태 파일 저장용 S3 버킷 및 DynamoDB 락 테이블 구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,10 @@ koco/backend/.terraform/
 koco/backend/*.tfstate
 koco/backend/*.tfstate.*
 
+koco/environments/dev/.terraform/
+koco/environments/dev/*.tfstate
+koco/environments/dev/*.tfstate.*
+
+koco/environments/prod/.terraform/
+koco/environments/prod/*.tfstate
+koco/environments/prod/*.tfstate.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+koco/backend/.terraform/
+koco/backend/*.tfstate
+koco/backend/*.tfstate.*
+

--- a/koco/backend/.terraform.lock.hcl
+++ b/koco/backend/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "6.4.0"
+  hashes = [
+    "h1:2gKOcsPikRhuukFKc7zvsbNRoQt/P99CxCS4pLlo5Xk=",
+    "zh:05946a97a2d98d3a77f2dfb1133b39d61b1166f717f051a8aa44eca22a7446b0",
+    "zh:07278697234332b254e990fff84fa5608aabdb256a0dbed05dfe336905d385a1",
+    "zh:1b1ad46267c84fa474618048a9ad94a634cf5d0e5ec3c8e56a854638129ae4da",
+    "zh:1ff04914571b1dfa485358badbc81306e34d8ebec4aa1f96b8c1c3d2eb0e4d4a",
+    "zh:43d7fb899186ca1b355af908d0904ea94a1e06de220de0b9752f06465386f66f",
+    "zh:49ce34c359d5b05ba684482dace5e9c418f3beabcc2b0d129b21687cb7673cab",
+    "zh:4bbad3a23dd704b1548da40e9c81befb617a0c02e5a9776ef0eff5ef920881c5",
+    "zh:680aa4bd542c7a847f7df91cd1fa33fe8d19914aa80a2570ea6c82ab2d1f5740",
+    "zh:792a74fe4d6b501571c582c25067f7f4dbdce2305d559d09981e7f99025c98ef",
+    "zh:7c06b331b6a6f160d2d64245b9aee32922a9cb9947b7a9ad8c0ec93a702ecb1b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f40add95d4f3e1c62df46bf37e13c30023d97eda47d4940904792f3b1a1827e",
+    "zh:b763c7c1bf5d8077d6499fd270cad249a712dd9522c6a6e4de49b278280806c5",
+    "zh:db69df59bef6f9d8bcb164414b4efa52c0c531c346d6b8b232917afa9b1c4a96",
+    "zh:dd9f98f64530386b8faaf9c55ec4b08e58725788c38683272a34684d82f866f7",
+  ]
+}

--- a/koco/backend/main.tf
+++ b/koco/backend/main.tf
@@ -1,0 +1,39 @@
+resource "aws_s3_bucket" "terraform_state" { 
+  bucket = var.bucket_name
+  force_destroy = false
+}
+
+resource "aws_s3_bucket_versioning" "enabled" { 
+  bucket = aws_s3_bucket.terraform_state.id 
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "default" { 
+  bucket = aws_s3_bucket.terraform_state.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "public_access" {
+  bucket = aws_s3_bucket.terraform_state.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_dynamodb_table" "terraform_lock" {
+  name         = var.bucket_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}

--- a/koco/backend/variables.tf
+++ b/koco/backend/variables.tf
@@ -1,0 +1,4 @@
+variable "bucket_name" {
+  type = string
+  default = "koco-terraformstate"
+}

--- a/koco/environments/dev/.terraform.lock.hcl
+++ b/koco/environments/dev/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.95.0"
+  constraints = "~> 5.95.0"
+  hashes = [
+    "h1:PUug/LLWa4GM08rXqnmCVUXj8ibCTvQxgvawhat3bMo=",
+    "zh:20aac8c95edd444e659f235d19fa6af9b259c5a70fce19d400539ee88687e7d4",
+    "zh:29c55846fadd19dde0c5108f74d507c296d6c37cabdd466a96d3721a7c261743",
+    "zh:325fa5cb42d58c9203c279450863c49e534672f7101c067af465f9d7f4be3be5",
+    "zh:4f18c643584f7ba554399c0db3dd1c81629dfc2508a8777890f9f3b80b5213b7",
+    "zh:561e38e9cc6f0be5470c187ea8d51047c4133d9cb74cc1c364a9ebe41f40a06b",
+    "zh:6ec2cceed96ca5e47591ef11686614c663b05e112a814d24246a2739066577b6",
+    "zh:710a227c02b8a50f75a82a7f063d2416e85783e02ed91bb22cc12e7a8e11a3cf",
+    "zh:97a2f5e9bf4cf9a38274eddb7967e1cb4e5b04960c7da3603d9b1c15e18b8626",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:bf6bfb01fff8226d86c1b219d67cd96f37bb9312b17d00340e6ff00dda2dbe82",
+    "zh:cba74d606149cbaaa8dfb69f369f2496b851643a879adc24b11515fcece42b66",
+    "zh:d5a2c36739cab677a48f4856958c96be6f018ff0da50d233ca93a3a21aaceca1",
+    "zh:df5d1466144852fe5da4af0628db6f02b5186c59f683e5085705d9b90cacfbc0",
+    "zh:f82d96b45983b3c73b78dced9e344512b7a9adb06e8c1e3e4f422605efbb756d",
+    "zh:fb523f787077270059a8f3ab52c0fc56257c0b3a06f0219be247c8b15ff0ca2a",
+  ]
+}

--- a/koco/environments/dev/provider.tf
+++ b/koco/environments/dev/provider.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.95.0"
+    }
+  }
+
+  # 백엔드 설정: 원격 상태 저장소를 사용하는 경우 설정
+  backend "s3" {                                # Terraform 상태 파일(terraform.tfstate)을 S3에 저장하도록 설정
+    bucket = "koco-terraformstate"              # 버킷 이름
+    key  = "./terraform.tfstate"                # dev 환경의 상태파일을 이 경로에 저장하겠다는 의미
+    region = "ap-northeast-2"                   # 버킷이 존재하는 region
+    encrypt = true                              # S3 버킷에 저장되는 상태 파일을 자동으로 암호화
+    dynamodb_table = "koco-terraformstate"      # DynamoDB 테이블을 통해 동시 작업 잠금 기능을 활성화하여 작업 중 충돌을 방지
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/koco/environments/dev/variables.tf
+++ b/koco/environments/dev/variables.tf
@@ -1,0 +1,5 @@
+variable "region" {
+  type = string
+  default = "ap-northeast-2"
+  description = "AWS Region"
+}

--- a/koco/environments/prod/.terraform.lock.hcl
+++ b/koco/environments/prod/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.95.0"
+  constraints = "~> 5.95.0"
+  hashes = [
+    "h1:PUug/LLWa4GM08rXqnmCVUXj8ibCTvQxgvawhat3bMo=",
+    "zh:20aac8c95edd444e659f235d19fa6af9b259c5a70fce19d400539ee88687e7d4",
+    "zh:29c55846fadd19dde0c5108f74d507c296d6c37cabdd466a96d3721a7c261743",
+    "zh:325fa5cb42d58c9203c279450863c49e534672f7101c067af465f9d7f4be3be5",
+    "zh:4f18c643584f7ba554399c0db3dd1c81629dfc2508a8777890f9f3b80b5213b7",
+    "zh:561e38e9cc6f0be5470c187ea8d51047c4133d9cb74cc1c364a9ebe41f40a06b",
+    "zh:6ec2cceed96ca5e47591ef11686614c663b05e112a814d24246a2739066577b6",
+    "zh:710a227c02b8a50f75a82a7f063d2416e85783e02ed91bb22cc12e7a8e11a3cf",
+    "zh:97a2f5e9bf4cf9a38274eddb7967e1cb4e5b04960c7da3603d9b1c15e18b8626",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:bf6bfb01fff8226d86c1b219d67cd96f37bb9312b17d00340e6ff00dda2dbe82",
+    "zh:cba74d606149cbaaa8dfb69f369f2496b851643a879adc24b11515fcece42b66",
+    "zh:d5a2c36739cab677a48f4856958c96be6f018ff0da50d233ca93a3a21aaceca1",
+    "zh:df5d1466144852fe5da4af0628db6f02b5186c59f683e5085705d9b90cacfbc0",
+    "zh:f82d96b45983b3c73b78dced9e344512b7a9adb06e8c1e3e4f422605efbb756d",
+    "zh:fb523f787077270059a8f3ab52c0fc56257c0b3a06f0219be247c8b15ff0ca2a",
+  ]
+}

--- a/koco/environments/prod/provider.tf
+++ b/koco/environments/prod/provider.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.95.0"
+    }
+  }
+
+  # 백엔드 설정: 원격 상태 저장소를 사용하는 경우 설정
+  backend "s3" {                                # Terraform 상태 파일(terraform.tfstate)을 S3에 저장하도록 설정
+    bucket = "koco-terraformstate"              # 버킷 이름
+    key  = "./terraform.tfstate"                # dev 환경의 상태파일을 이 경로에 저장하겠다는 의미
+    region = "ap-northeast-2"                   # 버킷이 존재하는 region
+    encrypt = true                              # S3 버킷에 저장되는 상태 파일을 자동으로 암호화
+    dynamodb_table = "koco-terraformstate"      # DynamoDB 테이블을 통해 동시 작업 잠금 기능을 활성화하여 작업 중 충돌을 방지
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/koco/environments/prod/variables.tf
+++ b/koco/environments/prod/variables.tf
@@ -1,0 +1,5 @@
+variable "region" {
+  type = string
+  default = "ap-northeast-2"
+  description = "AWS Region"
+}


### PR DESCRIPTION
# TITLE
[Feat] Terraform 상태 파일 저장용 S3 버킷 및 DynamoDB 락 테이블 구성 (#1)

## 📝 개요
Terraform 상태 파일(tfstate)을 S3에 저장하도록 백엔드 설정
- backend "s3" 블록 추가 (bucket, key, region, dynamodb_table 등 포함)
- 상태 잠금(locking)을 위한 DynamoDB 테이블 구성
## 🔗 연관된 이슈
- #1 

## 🔄 변경사항 및 이유

## 🔗 참고 자료 (선택)
- 관련 문서나 링크가 있으면 첨부