### PR TITLE
Feat: DB 인스턴스 모듈 생성

### DIFF
--- a/koco/environments/dev/main.tf
+++ b/koco/environments/dev/main.tf
@@ -37,3 +37,17 @@ module "openvpn" {
     subnet_id = module.koco_vpc.public_az1_id
     vpc_security_group_ids = [module.koco_security_group.sg_openvpn_id]
 }
+
+module "db" {
+    source = "../../modules/db_instance"
+
+    stage               = var.stage
+    servicename         = var.servicename
+    tags                = var.openvpn_tags
+
+    subnet_private_id = module.koco_vpc.db_az1_id
+    security_group_db_sg_id = module.koco_security_group.sg_db_id
+    ip = var.db_ip
+
+    depends_on = [ module.koco_vpc ]
+}

--- a/koco/environments/dev/variables.tf
+++ b/koco/environments/dev/variables.tf
@@ -60,3 +60,16 @@ variable "openvpn_tags" {
     "name" = "koco-openvpn"
   }
 }
+
+#db
+variable "db_tags" {
+  type = map(string)
+  default = {
+    "name" = "koco-db"
+  }
+}
+
+variable "db_ip" {
+  type = string
+  default = "10.110.150.100"
+}

--- a/koco/environments/prod/main.tf
+++ b/koco/environments/prod/main.tf
@@ -37,3 +37,17 @@ module "openvpn" {
     subnet_id = module.koco_vpc.public_az1_id
     vpc_security_group_ids = [module.koco_security_group.sg_openvpn_id]
 }
+
+module "db" {
+    source = "../../modules/db_instance"
+
+    stage               = var.stage
+    servicename         = var.servicename
+    tags                = var.openvpn_tags
+
+    subnet_private_id = module.koco_vpc.db_az1_id
+    security_group_db_sg_id = module.koco_security_group.sg_db_id
+    ip = var.db_ip
+
+    depends_on = [ module.koco_vpc ]
+}

--- a/koco/environments/prod/variables.tf
+++ b/koco/environments/prod/variables.tf
@@ -60,3 +60,16 @@ variable "openvpn_tags" {
     "name" = "koco-openvpn"
   }
 }
+
+#db
+variable "db_tags" {
+  type = map(string)
+  default = {
+    "name" = "koco-db"
+  }
+}
+
+variable "db_ip" {
+  type = string
+  default = "10.120.150.100"
+}

--- a/koco/modules/db_instance/main.tf
+++ b/koco/modules/db_instance/main.tf
@@ -1,0 +1,119 @@
+resource "aws_iam_role" "ec2_s3_access" {
+  name = "ec2-to-s3-access-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect = "Allow",
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      },
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "s3_access_policy" {
+  name = "S3ReadAccess"
+  role = aws_iam_role.ec2_s3_access.name
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = "arn:aws:s3:::koco-db-backup"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject"]
+        Resource = "arn:aws:s3:::koco-db-backup/*"
+      }
+    ]
+  })
+}
+
+
+resource "aws_iam_instance_profile" "ec2_profile" {
+  name = "ec2-to-s3-access-profile"
+  role = aws_iam_role.ec2_s3_access.name
+}
+
+resource "aws_instance" "mysql_server" {
+  ami                    = "ami-05a7f3469a7653972"
+  instance_type          = "t3.medium"
+  subnet_id              = var.subnet_private_id
+  private_ip             = var.ip                           # 고정 프라이빗 IP 지정
+  vpc_security_group_ids = [var.security_group_db_sg_id]
+  key_name               = var.key_pair_name
+  iam_instance_profile = aws_iam_instance_profile.ec2_profile.name
+
+  user_data = base64encode(<<-EOF
+    #!/bin/bash
+    set -e
+    export DEBIAN_FRONTEND=noninteractive
+
+    echo "=== Installing MySQL from MySQL APT Repository ==="
+    wget https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb
+    DEBIAN_FRONTEND=noninteractive dpkg -i mysql-apt-config_0.8.29-1_all.deb
+
+    echo "=== Installing MySQL ==="
+    apt-get update
+    apt-get install -y mysql-server
+
+    echo "=== Configuring MySQL ==="
+    # 모든 IP에서 접속 허용
+    sed -i 's/^bind-address\s*=.*$/bind-address = 0.0.0.0/' /etc/mysql/mysql.conf.d/mysqld.cnf
+    sed -i 's/^mysqlx-bind-address\s*=.*$/mysqlx-bind-address = 0.0.0.0/' /etc/mysql/mysql.conf.d/mysqld.cnf
+
+    echo "=== Starting MySQL ==="
+    systemctl enable mysql
+    systemctl restart mysql
+
+    echo "=== Creating MySQL Users ==="
+    mysql --user=root <<EOSQL
+    ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'koco';
+    CREATE USER IF NOT EXISTS 'was_user'@'%' IDENTIFIED BY 'koco';
+    GRANT ALL PRIVILEGES ON koco.* TO 'was_user'@'%';
+    FLUSH PRIVILEGES;
+    EOSQL
+
+    echo "=== Installing AWS CLI ==="
+    apt-get install -y unzip curl
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+    unzip -q awscliv2.zip
+    ./aws/install
+
+    echo "=== Restoring Backup from S3 ==="
+    TMP_DIR="/tmp/koco-db"
+    mkdir -p "$TMP_DIR"
+    chown ubuntu:ubuntu "$TMP_DIR" || true
+    cd "$TMP_DIR"
+
+    # 최신 백업 파일 추출
+    LATEST_BACKUP=$(aws s3 ls s3://koco-db-backup/ --recursive \
+      | awk '{print $4}' \
+      | grep -E '^koco_[0-9]{8}\.sql$' \
+      | sort -V \
+      | tail -n1)
+
+    if [ -z "$LATEST_BACKUP" ]; then
+      echo "❌ No backup file found. Skipping restore."
+      exit 1
+    fi
+
+    echo "✅ Latest backup file: $LATEST_BACKUP"
+    aws s3 cp "s3://koco-db-backup/$LATEST_BACKUP" .
+
+    echo "=== Restoring to MySQL ==="
+    mysql -u root -pkoco -e "CREATE DATABASE IF NOT EXISTS koco;"
+    mysql -u root -pkoco koco < "$LATEST_BACKUP"
+
+    echo "✅ All done."
+    EOF
+  )
+
+  tags = merge(tomap({
+        Name =  "db-${var.stage}-${var.servicename}"}), var.tags)
+}

--- a/koco/modules/db_instance/variables.tf
+++ b/koco/modules/db_instance/variables.tf
@@ -1,0 +1,30 @@
+variable "tags"{
+  type = map(string)
+}
+variable "stage" {
+  type = string
+}
+variable "servicename" {
+  type = string
+}
+
+variable "key_pair_name" {
+  description = "인스턴스 키페어"
+  type        = string
+  default     = ""
+}
+
+variable "security_group_db_sg_id" {
+  description = "db 보안 그룹 ID"
+  type        = string
+}
+
+variable "subnet_private_id" {
+  description = "인스턴스가 생성될 프라이빗 서브넷 ID"
+  type        = string
+}
+
+variable "ip" {
+  description = "인스턴스에 부여될 고정 ip"
+  type        = string
+}


### PR DESCRIPTION
# TITLE
[Feat] DB용 EC2 인스턴스 모듈 구성(#5)

## 📝 개요
- DB 전용 EC2 인스턴스를 생성하고, Private 서브넷에 배치

## 🔗 연관된 이슈
- #5

## 🔄 변경사항 및 이유

## 📋 작업할 내용
- [ ] DB용 EC2 인스턴스 생성 (AMI, 인스턴스 타입, EBS 볼륨 설정 등)
- [ ] Private 서브넷에 배치
- [ ] DB 보안 그룹 연결 (애플리케이션 서버로부터의 접근만 허용)

## 🔗 참고 자료 (선택)
- 관련 문서나 링크가 있으면 첨부