### PR TITLE
Feat: S3 정적 호스팅 모듈 구성

### DIFF
--- a/koco/environments/dev/main.tf
+++ b/koco/environments/dev/main.tf
@@ -164,3 +164,9 @@ module "helm" {
 
     depends_on = [module.koco_vpc, module.eks, module.sa, module.iam] 
 }
+
+module "s3_static_site" {
+  source              = "../../modules/s3_static_site"
+  cloudfront_oai_arn  = ""
+  bucket_name = var.s3-static-bucket-name
+}

--- a/koco/environments/dev/variables.tf
+++ b/koco/environments/dev/variables.tf
@@ -83,3 +83,9 @@ variable "acm_certificate_arn" {
   type = string
   default = ""
 }
+
+#s3-static-site
+variable "s3-static-bucket-name" {
+  type = string
+  default = "prod-koco-front-s3"
+}

--- a/koco/environments/prod/main.tf
+++ b/koco/environments/prod/main.tf
@@ -163,3 +163,9 @@ module "helm" {
 
     depends_on = [module.koco_vpc, module.eks, module.sa, module.iam] 
 }
+
+module "s3_static_site" {
+  source              = "../../modules/s3_static_site"
+  cloudfront_oai_arn  = ""
+  bucket_name = var.s3-static-bucket-name
+}

--- a/koco/environments/prod/variables.tf
+++ b/koco/environments/prod/variables.tf
@@ -83,3 +83,9 @@ variable "acm_certificate_arn" {
   type = string
   default = ""
 }
+
+#s3-static-site
+variable "s3-static-bucket-name" {
+  type = string
+  default = "prod-koco-front-s3"
+}

--- a/koco/modules/s3_static_site/main.tf
+++ b/koco/modules/s3_static_site/main.tf
@@ -1,0 +1,49 @@
+resource "aws_s3_bucket" "frontend" {
+  bucket = var.bucket_name 
+  #force_destroy = false     # 버킷 비우기 없이 삭제 방지
+
+  # lifecycle {
+  #   prevent_destroy = true       # 실수로 삭제되는 것 방지
+  # }
+}
+
+resource "aws_s3_bucket_website_configuration" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "index.html"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "frontend" {
+  bucket     = aws_s3_bucket.frontend.id
+  depends_on = [aws_s3_bucket_public_access_block.frontend]
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid       = "AllowCloudFrontAccess",
+        Effect    = "Allow",
+        Principal = {
+          AWS = var.cloudfront_oai_arn
+        },
+        Action    = "s3:GetObject",
+        Resource  = "${aws_s3_bucket.frontend.arn}/*"
+      }
+    ]
+  })
+}

--- a/koco/modules/s3_static_site/outputs.tf
+++ b/koco/modules/s3_static_site/outputs.tf
@@ -1,0 +1,7 @@
+output "dns_name" {
+    value = aws_s3_bucket.frontend.bucket_domain_name
+}
+output "s3_bucket_name" {
+  description = "정적 웹사이트 호스팅용 S3 버킷 이름"
+  value       = aws_s3_bucket.frontend.bucket
+}

--- a/koco/modules/s3_static_site/variables.tf
+++ b/koco/modules/s3_static_site/variables.tf
@@ -1,0 +1,8 @@
+variable "bucket_name" {
+  description = "Frontend static hosting bucket name"
+  type        = string
+}
+variable "cloudfront_oai_arn" {
+  description = "CloudFront Origin Access Identity의 IAM ARN"
+  type        = string
+}


### PR DESCRIPTION
# TITLE
[Feat] S3 정적 호스팅 모듈 구성 (#15)

## 📝 개요
- 정적 웹 호스팅을 위한 S3 버킷 모듈을 구성합니다. CDN과의 연동을 고려하여 OAI 및 버킷 정책을 포함합니다.

## 🔗 연관된 이슈
- #15 

## 🔄 변경사항 및 이유

## 📋 작업할 내용

## 🔖 기타사항

## 👀 리뷰 요구사항 (선택)
- 리뷰어에게 특별히 확인받고 싶은 부분이 있으면 작성
- ex) "메서드 네이밍을 더 직관적으로 만들고 싶은데 조언 부탁드립니다."

## 🔗 참고 자료 (선택)
- 관련 문서나 링크가 있으면 첨부